### PR TITLE
Reflecting actual requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,14 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "illuminate/contracts": "^8.0",
         "illuminate/support": "^8.0",
         "laravel/dusk": "^6.0",
         "psy/psysh": "^0.10.4",
         "spatie/backtrace": "^1.1",
-        "spatie/laravel-package-tools": "^1.1"
+        "spatie/laravel-package-tools": "^1.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Arrow functions

https://github.com/magic-test/magic-test-laravel/blob/1c7ea46ed8ffd881c282ad42f8281477e5c5f875/src/Parser/File.php#L63-L66

and typed properties

https://github.com/magic-test/magic-test-laravel/blob/1c7ea46ed8ffd881c282ad42f8281477e5c5f875/src/Parser/File.php#L12-L16

were introduced in php 7.4 https://www.php.net/releases/7_4_0.php


`json_decode` is called here:
https://github.com/magic-test/magic-test-laravel/blob/1c7ea46ed8ffd881c282ad42f8281477e5c5f875/src/MagicTestManager.php#L52