### PR TITLE
Add 'dusk' as an allowed environment for the MagicTestMiddleware

### DIFF
--- a/src/Middleware/MagicTestMiddleware.php
+++ b/src/Middleware/MagicTestMiddleware.php
@@ -19,7 +19,7 @@ class MagicTestMiddleware
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (! app()->environment(['local', 'testing'])) {
+        if (! app()->environment(['local', 'testing', 'dusk'])) {
             return $next($request);
         }
 


### PR DESCRIPTION
For those of us who run our Dusk tests in a dedicated environment, scripts aren't loaded by the middleware as it requires either `local` or `testing`. I've added `dusk` to allow them to be included.

I expect most people won't be affected by this, this is more niche for some apps which like to more clearly identify the execution context, but it saves having to override the middleware entirely.

Thanks!